### PR TITLE
Jwt 인증 필터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.1'
+	implementation group: 'com.auth0', name: 'java-jwt', version: '3.1.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/tcp/toeflserver/data/LoginData.java
+++ b/src/main/java/com/tcp/toeflserver/data/LoginData.java
@@ -1,0 +1,9 @@
+package com.tcp.toeflserver.data;
+
+import lombok.Data;
+
+@Data
+public class LoginData {
+    private String id;
+    private String password;
+}

--- a/src/main/java/com/tcp/toeflserver/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tcp/toeflserver/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.tcp.toeflserver.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tcp.toeflserver.data.LoginData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        LoginData credentials = null;
+
+        try{
+            credentials = new ObjectMapper().readValue(request.getInputStream(), LoginData.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                credentials.getId(),
+                credentials.getPassword(),
+                new ArrayList<>()
+        );
+
+        Authentication auth = authenticationManager.authenticate(authenticationToken);
+        return auth;
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        System.out.println(authResult.getPrincipal());
+        User principal = (User)authResult.getPrincipal();
+
+        String token = JWT.create()
+                .withSubject(principal.getUsername())
+                .withExpiresAt(new Date(System.currentTimeMillis() + JwtProperties.EXPIRATION_TIME))
+                .sign(Algorithm.HMAC256(JwtProperties.SECRET.getBytes()));
+
+        response.addHeader(JwtProperties.HEADER_STRING, JwtProperties.TOKEN_PREFIX + token);
+    }
+}

--- a/src/main/java/com/tcp/toeflserver/security/JwtProperties.java
+++ b/src/main/java/com/tcp/toeflserver/security/JwtProperties.java
@@ -1,0 +1,8 @@
+package com.tcp.toeflserver.security;
+
+public class JwtProperties {
+    public static final String SECRET = "tcp";
+    public static final int EXPIRATION_TIME = 24*60*60*1000;
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String HEADER_STRING = "Authorization";
+}

--- a/src/main/java/com/tcp/toeflserver/security/SecurityConfig.java
+++ b/src/main/java/com/tcp/toeflserver/security/SecurityConfig.java
@@ -1,0 +1,46 @@
+package com.tcp.toeflserver.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.
+            csrf().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .addFilter(new JwtAuthenticationFilter(authenticationManager()))
+            .authorizeRequests()
+            .antMatchers(HttpMethod.POST,"/login").permitAll()
+            .anyRequest().authenticated();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        //for test
+        String password = passwordEncoder().encode("practice");
+        auth
+            .inMemoryAuthentication()
+            .passwordEncoder(passwordEncoder())
+            .withUser("practice")
+            .password(password)
+            .authorities("ROLE_USER");
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder(){
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}


### PR DESCRIPTION
#4 

- jwt 프로퍼티 설정, jwt 인증 필터 구현했습니다. (아직 user 저장소가 없습니다. inMemoryAuthentication로 임의 username/password 만들어서 테스트)
- api에서 제시한 url과 다르게 되어 있습니다.. (api에서는 /user/login 사용. 이 코드에서는 /login 사용)
- url을 바꾸는 방법이 있는 것 같은데 조금 더 고민해봐야할듯 합니다.