### PR TITLE
#5 user api 회원 정보 보기. Authorization 등 구현

### DIFF
--- a/src/main/java/com/tcp/toeflserver/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/tcp/toeflserver/security/JwtAuthorizationFilter.java
@@ -1,0 +1,52 @@
+package com.tcp.toeflserver.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.tcp.toeflserver.user.CustomUser;
+import com.tcp.toeflserver.user.CustomUserRepository;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
+    private final CustomUserRepository userRepository;
+
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, CustomUserRepository userRepository) {
+        super(authenticationManager);
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        Authentication authentication = getUserDataAuthentication(request);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        chain.doFilter(request, response);
+    }
+
+    private Authentication getUserDataAuthentication(HttpServletRequest request) {
+        String header = Optional.ofNullable(request.getHeader(JwtProperties.HEADER_STRING)).orElse("");
+
+        if(!header.startsWith(JwtProperties.TOKEN_PREFIX)){
+            return null;
+        }
+
+        String id = JWT.require(Algorithm.HMAC256(JwtProperties.SECRET.getBytes()))
+                .build()
+                .verify(header.replace(JwtProperties.TOKEN_PREFIX, ""))
+                .getSubject();
+
+        CustomUser user = Optional.ofNullable(userRepository.findUserById(id)).orElse(new CustomUser());
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(id, null, user.getAuthorities());
+        return authenticationToken;
+    }
+}

--- a/src/main/java/com/tcp/toeflserver/security/SecurityConfig.java
+++ b/src/main/java/com/tcp/toeflserver/security/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .addFilter(new JwtAuthenticationFilter(authenticationManager()))
             .addFilter(new JwtAuthorizationFilter(authenticationManager(), userRepository))
             .authorizeRequests()
-            .antMatchers(HttpMethod.POST,"/login", "/user").permitAll()
+            .antMatchers(HttpMethod.PUT, "/user/id/confirmrepetition", "/user/nickname/confirmrepetition").permitAll()
+            .antMatchers(HttpMethod.POST,"/login", "/user", "/user/email", "/user/email/validation").permitAll()
             .anyRequest().authenticated();
     }
 

--- a/src/main/java/com/tcp/toeflserver/security/SecurityConfig.java
+++ b/src/main/java/com/tcp/toeflserver/security/SecurityConfig.java
@@ -1,17 +1,15 @@
 package com.tcp.toeflserver.security;
 
-import com.tcp.toeflserver.user.CustomUserDAO;
 import com.tcp.toeflserver.user.CustomUserDetailsService;
+import com.tcp.toeflserver.user.CustomUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -19,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final CustomUserDetailsService userDetailsService;
+    private final CustomUserRepository userRepository;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -27,6 +26,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .addFilter(new JwtAuthenticationFilter(authenticationManager()))
+            .addFilter(new JwtAuthorizationFilter(authenticationManager(), userRepository))
             .authorizeRequests()
             .antMatchers(HttpMethod.POST,"/login", "/user").permitAll()
             .anyRequest().authenticated();

--- a/src/main/java/com/tcp/toeflserver/user/CustomUser.java
+++ b/src/main/java/com/tcp/toeflserver/user/CustomUser.java
@@ -1,9 +1,9 @@
 package com.tcp.toeflserver.user;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -11,8 +11,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.ArrayList;
 import java.util.Collection;
 
-@Getter
-@Setter
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties({"authority", "enabled", "username", "authorities", "accountNonExpired", "accountNonLocked", "credentialsNonExpired"})
 public class CustomUser  implements UserDetails {
 

--- a/src/main/java/com/tcp/toeflserver/user/CustomUserDetailsService.java
+++ b/src/main/java/com/tcp/toeflserver/user/CustomUserDetailsService.java
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
-    private final CustomUserDAO customUserDAO;
+    private final CustomUserRepository customUserRepository;
 
     @Override
     public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-        CustomUser user = customUserDAO.findUserById(id);
+        CustomUser user = customUserRepository.findUserById(id);
 
         if(user == null){
             throw new UsernameNotFoundException(id);
@@ -30,7 +30,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         user.setPassword(passwordEncoder.encode(user.getPassword()));
 
         try{
-            customUserDAO.saveUser(user);
+            customUserRepository.saveUser(user);
             return true;
         } catch (DataAccessException e){
             return false;

--- a/src/main/java/com/tcp/toeflserver/user/CustomUserDetailsService.java
+++ b/src/main/java/com/tcp/toeflserver/user/CustomUserDetailsService.java
@@ -2,6 +2,7 @@ package com.tcp.toeflserver.user;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -23,6 +24,14 @@ public class CustomUserDetailsService implements UserDetailsService {
         }
 
         return user;
+    }
+
+    public CustomUser findUserInformation(String id){
+        if(!id.equals(SecurityContextHolder.getContext().getAuthentication().getName())){
+            return null;
+        }
+
+        return customUserRepository.findUserById(id);
     }
 
     public boolean signUp(CustomUser user){

--- a/src/main/java/com/tcp/toeflserver/user/CustomUserDetailsService.java
+++ b/src/main/java/com/tcp/toeflserver/user/CustomUserDetailsService.java
@@ -36,4 +36,12 @@ public class CustomUserDetailsService implements UserDetailsService {
             return false;
         }
     }
+
+    public boolean isAvailableForId(String id){
+        return customUserRepository.findUserById(id) == null;
+    }
+
+    public boolean isAvailableForNickname(String nickname){
+        return customUserRepository.findUserByNickname(nickname) == null;
+    }
 }

--- a/src/main/java/com/tcp/toeflserver/user/CustomUserMapper.java
+++ b/src/main/java/com/tcp/toeflserver/user/CustomUserMapper.java
@@ -1,0 +1,16 @@
+package com.tcp.toeflserver.user;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Select;
+
+public interface CustomUserMapper {
+
+    @Insert("insert into user( id, password, email, nickname ) values( #{id}, #{password}, #{email}, #{nickname} )")
+    void insertUser(CustomUser user);
+
+    @Select("select * from user where id=#{id}")
+    CustomUser selectUserById(String id);
+
+    @Select("select * from user where email=#{email}")
+    CustomUser selectUserByEmail(String email);
+}

--- a/src/main/java/com/tcp/toeflserver/user/CustomUserMapper.java
+++ b/src/main/java/com/tcp/toeflserver/user/CustomUserMapper.java
@@ -13,4 +13,7 @@ public interface CustomUserMapper {
 
     @Select("select * from user where email=#{email}")
     CustomUser selectUserByEmail(String email);
+
+    @Select("select * from user where nickname=#{nickname}")
+    CustomUser selectUserByNickname(String nickname);
 }

--- a/src/main/java/com/tcp/toeflserver/user/CustomUserRepository.java
+++ b/src/main/java/com/tcp/toeflserver/user/CustomUserRepository.java
@@ -25,6 +25,10 @@ public class CustomUserRepository {
         return mapper.selectUserByEmail(email);
     }
 
+    public CustomUser findUserByNickname(String nickname){
+        return mapper.selectUserByNickname(nickname);
+    }
+
     public void saveUser(CustomUser user) throws DataAccessException{
         mapper.insertUser(user);
     }

--- a/src/main/java/com/tcp/toeflserver/user/CustomUserRepository.java
+++ b/src/main/java/com/tcp/toeflserver/user/CustomUserRepository.java
@@ -1,5 +1,6 @@
 package com.tcp.toeflserver.user;
 
+import lombok.RequiredArgsConstructor;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
@@ -7,20 +8,24 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class CustomUserDAO {
+public class CustomUserRepository {
+    private final CustomUserMapper mapper;
 
     @Autowired
-    private SqlSessionTemplate sqlSession;
-
-    public CustomUser findUserById(String id){
-        return sqlSession.selectOne("user.selectUserById", id);
+    public CustomUserRepository(SqlSessionTemplate sqlSession){
+        this.mapper = sqlSession.getMapper(CustomUserMapper.class);
     }
 
-    public CustomUser findUserByEmail(String email){
-        return sqlSession.selectOne("user.selectUserByEmail", email);
+    public CustomUser findUserById(String id){
+        return mapper.selectUserById(id);
+    }
+
+    public CustomUser findUserByEmail(String email)
+    {
+        return mapper.selectUserByEmail(email);
     }
 
     public void saveUser(CustomUser user) throws DataAccessException{
-        sqlSession.insert("user.insertUser", user);
+        mapper.insertUser(user);
     }
 }

--- a/src/main/java/com/tcp/toeflserver/user/UserApiResponse.java
+++ b/src/main/java/com/tcp/toeflserver/user/UserApiResponse.java
@@ -1,0 +1,20 @@
+package com.tcp.toeflserver.user;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+public class UserApiResponse {
+    boolean success;
+    String token;
+    CustomUser userInformation;
+
+    @Builder
+    public UserApiResponse(boolean success, String token, CustomUser userInformation){
+        this.success = success;
+        this.token = token;
+        this.userInformation = userInformation;
+    }
+}

--- a/src/main/java/com/tcp/toeflserver/user/UserController.java
+++ b/src/main/java/com/tcp/toeflserver/user/UserController.java
@@ -1,11 +1,11 @@
 package com.tcp.toeflserver.user;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
@@ -17,14 +17,14 @@ public class UserController {
     @PostMapping
     public UserApiResponse signUp(@RequestBody CustomUser user) {
         UserApiResponse response = UserApiResponse.builder()
-            .success(customUserDetailsService.signUp(user))
-            .build();
+                .success(customUserDetailsService.signUp(user))
+                .build();
 
         return response;
     }
 
     @PutMapping(value = "/id/confirmrepetition")
-    public UserApiResponse idConfirmRepetition(@RequestBody HashMap<String, String> requestBody){
+    public UserApiResponse idConfirmRepetition(@RequestBody HashMap<String, String> requestBody) {
         UserApiResponse response = UserApiResponse.builder()
                 .success(customUserDetailsService.isAvailableForId(requestBody.get("id")))
                 .build();
@@ -33,9 +33,20 @@ public class UserController {
     }
 
     @PutMapping(value = "/nickname/confirmrepetition")
-    public UserApiResponse nicknameConfirmRepetition(@RequestBody HashMap<String, String> requestBody){
+    public UserApiResponse nicknameConfirmRepetition(@RequestBody HashMap<String, String> requestBody) {
         UserApiResponse response = UserApiResponse.builder()
                 .success(customUserDetailsService.isAvailableForNickname(requestBody.get("nickname")))
+                .build();
+
+        return response;
+    }
+
+    @GetMapping(value = "/{userId}")
+    public UserApiResponse getUserInformation(@PathVariable("userId") String id) {
+        CustomUser user = customUserDetailsService.findUserInformation(id);
+        UserApiResponse response =UserApiResponse.builder()
+                .success(user != null)
+                .userInformation(Optional.ofNullable(user).orElse(new CustomUser()))
                 .build();
 
         return response;

--- a/src/main/java/com/tcp/toeflserver/user/UserController.java
+++ b/src/main/java/com/tcp/toeflserver/user/UserController.java
@@ -1,6 +1,8 @@
 package com.tcp.toeflserver.user;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -13,12 +15,29 @@ public class UserController {
     private final CustomUserDetailsService customUserDetailsService;
 
     @PostMapping
-    @ResponseBody
-    public HashMap<String, Object> signUp(@RequestBody CustomUser user){
-        HashMap<String, Object> responseBody = new HashMap();
+    public UserApiResponse signUp(@RequestBody CustomUser user) {
+        UserApiResponse response = UserApiResponse.builder()
+            .success(customUserDetailsService.signUp(user))
+            .build();
 
-        responseBody.put("success", customUserDetailsService.signUp(user));
-        return responseBody;
+        return response;
+    }
+
+    @PutMapping(value = "/id/confirmrepetition")
+    public UserApiResponse idConfirmRepetition(@RequestBody HashMap<String, String> requestBody){
+        UserApiResponse response = UserApiResponse.builder()
+                .success(customUserDetailsService.isAvailableForId(requestBody.get("id")))
+                .build();
+
+        return response;
+    }
+
+    @PutMapping(value = "/nickname/confirmrepetition")
+    public UserApiResponse nicknameConfirmRepetition(@RequestBody HashMap<String, String> requestBody){
+        UserApiResponse response = UserApiResponse.builder()
+                .success(customUserDetailsService.isAvailableForNickname(requestBody.get("nickname")))
+                .build();
+
+        return response;
     }
 }
-

--- a/src/main/java/com/tcp/toeflserver/user/UserController.java
+++ b/src/main/java/com/tcp/toeflserver/user/UserController.java
@@ -12,7 +12,7 @@ public class UserController {
 
     private final CustomUserDetailsService customUserDetailsService;
 
-    @RequestMapping(method = RequestMethod.POST)
+    @PostMapping
     @ResponseBody
     public HashMap<String, Object> signUp(@RequestBody CustomUser user){
         HashMap<String, Object> responseBody = new HashMap();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,4 +12,4 @@ spring.mail.password=1234
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
-mybatis.mapper-locations=mapper/*.xml
+mybatis.config-location=classpath:mybatis-config.xml

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+    <mappers>
+        <mapper class="com.tcp.toeflserver.user.CustomUserMapper"/>
+    </mappers>
+</configuration>


### PR DESCRIPTION
#5 중간 점검 피드백 일부 반영했습니다(Request 타입 정의. 매퍼 인터페이스 사용. DAO 이름 바꾸기. 필드 주입 없애기)
아직 이메일 인증이 완료되어야 회원가입 가능하도록 하는 로직이 없습니다.. 빨리 만들겠습니다