### PR TITLE
#24 SelectReview 이름을 GetReviewsParams으로 변경. 서비스 실패시 예외 던지도록 변경

### DIFF
--- a/src/main/java/com/tcp/toeflserver/review/GetReviewsParams.java
+++ b/src/main/java/com/tcp/toeflserver/review/GetReviewsParams.java
@@ -3,7 +3,7 @@ package com.tcp.toeflserver.review;
 import lombok.Data;
 
 @Data
-public class SelectReview {
+public class GetReviewsParams {
     private String userId;
     private String placeId;
     private int page;

--- a/src/main/java/com/tcp/toeflserver/review/ReviewController.java
+++ b/src/main/java/com/tcp/toeflserver/review/ReviewController.java
@@ -15,8 +15,8 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @GetMapping
-    public ReviewApiResponse getReviewByPlace(SelectReview selectReview) {
-        List<Review> reviews = reviewService.getReviewsByPlace(selectReview);
+    public ReviewApiResponse getReviewsByPlace(GetReviewsParams getReviewsParams) {
+        List<Review> reviews = reviewService.getReviewsByPlace(getReviewsParams);
 
         ReviewApiResponse response = ReviewApiResponse.builder()
                 .success(reviews != null)
@@ -27,8 +27,8 @@ public class ReviewController {
     }
 
     @GetMapping("/myreview")
-    public ReviewApiResponse getReviewsByUser(SelectReview selectReview) {
-        List<Review> reviews = reviewService.getReviewsByUser(selectReview);
+    public ReviewApiResponse getMyReviews(GetReviewsParams getReviewsParams) {
+        List<Review> reviews = reviewService.getMyReviews(getReviewsParams);
 
         ReviewApiResponse response = ReviewApiResponse.builder()
                 .success(reviews != null)
@@ -40,26 +40,36 @@ public class ReviewController {
 
     @PostMapping
     public ReviewApiResponse addReview(@RequestBody Review review) {
-        String added = reviewService.addReview(review);
-        boolean success = added.equals("Success");
-
-        ReviewApiResponse response = ReviewApiResponse.builder()
-                .success(success)
-                .errMsg(success ? null : added)
-                .build();
+        ReviewApiResponse response;
+        try{
+            reviewService.addReview(review);
+            response = ReviewApiResponse.builder()
+                    .success(true)
+                    .build();
+        } catch (Exception e){
+            response = ReviewApiResponse.builder()
+                    .success(false)
+                    .errMsg(e.getMessage())
+                    .build();
+        }
 
         return response;
     }
 
     @DeleteMapping("/{reviewId}")
     public ReviewApiResponse deleteReview(@PathVariable String reviewId) {
-        String deleted = reviewService.removeReview(Integer.parseInt(reviewId));
-        boolean success = deleted.equals("Success");
-
-        ReviewApiResponse response = ReviewApiResponse.builder()
-                .success(success)
-                .errMsg(success ? null : deleted)
-                .build();
+        ReviewApiResponse response;
+        try{
+            reviewService.removeReview(Integer.parseInt(reviewId));
+            response = ReviewApiResponse.builder()
+                    .success(true)
+                    .build();
+        } catch (Exception e){
+            response = ReviewApiResponse.builder()
+                    .success(false)
+                    .errMsg(e.getMessage())
+                    .build();
+        }
 
         return response;
     }

--- a/src/main/java/com/tcp/toeflserver/review/ReviewController.java
+++ b/src/main/java/com/tcp/toeflserver/review/ReviewController.java
@@ -28,7 +28,7 @@ public class ReviewController {
 
     @GetMapping("/myreview")
     public ReviewApiResponse getMyReviews(GetReviewsParams getReviewsParams) {
-        List<Review> reviews = reviewService.getMyReviews(getReviewsParams);
+        List<Review> reviews = reviewService.getReviewsByRequester(getReviewsParams);
 
         ReviewApiResponse response = ReviewApiResponse.builder()
                 .success(reviews != null)

--- a/src/main/java/com/tcp/toeflserver/review/ReviewMapper.java
+++ b/src/main/java/com/tcp/toeflserver/review/ReviewMapper.java
@@ -12,11 +12,11 @@ public interface ReviewMapper {
 
     @Select("SELECT reviews.* FROM ( SELECT * FROM review WHERE user_id=#{userId} order by ${sort} ${order})reviews LIMIT #{offset}, 20")
     @ResultType(com.tcp.toeflserver.review.Review.class)
-    List<Review> selectReviewsByUser(SelectReview review);
+    List<Review> selectReviewsByUser(GetReviewsParams getReviewsParams);
 
     @Select("SELECT reviews.* FROM ( SELECT * FROM review WHERE place_id=#{placeId} order by ${sort} ${order})reviews LIMIT #{offset}, 20")
     @ResultType(com.tcp.toeflserver.review.Review.class)
-    List<Review> selectReviewsByPlace(SelectReview selectReview);
+    List<Review> selectReviewsByPlace(GetReviewsParams getReviewsParams);
 
     @Insert("insert into review(place_id, user_id, score, date, content) values (#{placeId}, #{userId}, #{score}, #{date}, #{content})")
     void insertReview(Review review);

--- a/src/main/java/com/tcp/toeflserver/review/ReviewRepository.java
+++ b/src/main/java/com/tcp/toeflserver/review/ReviewRepository.java
@@ -24,12 +24,12 @@ public class ReviewRepository {
         reviewMapper.insertReview(review);
     }
 
-    public List<Review> selectReviewsByPlace(SelectReview selectReview) {
-        return reviewMapper.selectReviewsByPlace(selectReview);
+    public List<Review> selectReviewsByPlace(GetReviewsParams getReviewsParams) {
+        return reviewMapper.selectReviewsByPlace(getReviewsParams);
     }
 
-    public List<Review> selectReviewsByUser(SelectReview selectReview) {
-        return reviewMapper.selectReviewsByUser(selectReview);
+    public List<Review> selectReviewsByUser(GetReviewsParams getReviewsParams) {
+        return reviewMapper.selectReviewsByUser(getReviewsParams);
     }
 
     public Review selectReviewByIndex(int id) {

--- a/src/main/java/com/tcp/toeflserver/review/ReviewService.java
+++ b/src/main/java/com/tcp/toeflserver/review/ReviewService.java
@@ -10,13 +10,13 @@ import java.util.List;
 public class ReviewService {
     private final ReviewRepository reviewRepository;
 
-    List<Review> getMyReviews(GetReviewsParams selectReview) {
-        selectReview.setUserId(SecurityContextHolder.getContext().getAuthentication().getName());
-        return reviewRepository.selectReviewsByUser(selectReview);
+    List<Review> getReviewsByRequester(GetReviewsParams getReviewsParams) {
+        getReviewsParams.setUserId(SecurityContextHolder.getContext().getAuthentication().getName());
+        return reviewRepository.selectReviewsByUser(getReviewsParams);
     }
 
-    List<Review> getReviewsByPlace(GetReviewsParams selectReview) {
-        return reviewRepository.selectReviewsByPlace(selectReview);
+    List<Review> getReviewsByPlace(GetReviewsParams getReviewsParams) {
+        return reviewRepository.selectReviewsByPlace(getReviewsParams);
     }
 
     void removeReview(int id) throws Exception {

--- a/src/main/java/com/tcp/toeflserver/review/ReviewService.java
+++ b/src/main/java/com/tcp/toeflserver/review/ReviewService.java
@@ -10,39 +10,29 @@ import java.util.List;
 public class ReviewService {
     private final ReviewRepository reviewRepository;
 
-    List<Review> getReviewsByUser(SelectReview selectReview){
+    List<Review> getMyReviews(GetReviewsParams selectReview) {
         selectReview.setUserId(SecurityContextHolder.getContext().getAuthentication().getName());
         return reviewRepository.selectReviewsByUser(selectReview);
     }
 
-    List<Review> getReviewsByPlace(SelectReview selectReview){
+    List<Review> getReviewsByPlace(GetReviewsParams selectReview) {
         return reviewRepository.selectReviewsByPlace(selectReview);
     }
 
-    String removeReview(int id) {
+    void removeReview(int id) throws Exception {
         String ownUserId = SecurityContextHolder.getContext().getAuthentication().getName();
-        try {
-            if(!reviewRepository.selectReviewByIndex(id).getUserId().equals(ownUserId)){
-                return "It's not yours";
-            }
-            reviewRepository.deleteReview(id);
-            return "Success";
+        Review targetReview = reviewRepository.selectReviewByIndex(id);
+
+        if (!targetReview.getUserId().equals(ownUserId)) {
+            throw new Exception("it's not yours");
         }
-        catch (Exception e){
-            return e.getMessage();
-        }
+
+        reviewRepository.deleteReview(id);
     }
 
-    String addReview(Review review){
+    void addReview(Review review) throws Exception {
         review.setUserId(SecurityContextHolder.getContext().getAuthentication().getName());
         review.setTimeToNow();
-
-        try {
-            reviewRepository.insertReview(review);
-            return "Success";
-        }
-        catch (Exception e){
-            return e.getMessage();
-        }
+        reviewRepository.insertReview(review);
     }
 }


### PR DESCRIPTION
저번 피드백 반영해서 수정했습니다. 
- - -
피드백 받았던 부분들
- SelectReview라는 이름은 의미를 잘 전달하지 못한다(Review 리스트를 요청하는 인자들을 모아놓은 타입)
- 문자열을 반환하지 말고 명시적인 에러를 반환해야한다